### PR TITLE
Fixes squirrely margins

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -337,3 +337,13 @@ header #logo, header nav {
   }
 
 }
+
+@media (max-width: 768px) {
+    .row {
+      flex-direction: column;
+    }
+    .col-xs {
+      width: 100%;
+      max-width: 100%;
+    }
+  }

--- a/templates/page.html
+++ b/templates/page.html
@@ -21,7 +21,7 @@
 {% block content %}
 <main class="container">
   <section class="row">
-    <div class="col-xs-12">
+    <div class="col-xs">
       <article>
       <h1>{{ page.title }}</h1>
       <p><i>{{ page.description }}</i></p>
@@ -52,12 +52,12 @@
             {% endif %}
             <div class="row">
                 {% if page.extra.feature_photo != "" %}
-                  <div class="col-sm-2">
+                  <div class="col-xs">
                     <p><img src="{{ get_url(path=page.extra.feature_photo) }}" alt="{{ page.extra.feature_photo_alt }}" /></p>
                   </div>
-                  <div class="col-sm-10">
+                  <div class="col-xs">
                 {% else %}
-                    <div class="col-xs-12">
+                    <div class="col-xs">
                 {% endif %}
                 <p>{{ page.content | safe }}</p>
                 </div>

--- a/templates/podcast.html
+++ b/templates/podcast.html
@@ -32,14 +32,14 @@
     {% for page in section.pages %}
       <div {% if loop.index % 2 == 0 %}{% endif %}>
       <div class="container">
-        <section class="row middle-lg">
+        <section class="row">
           {% if page.extra.feature_photo != "" %}
-            <div class="col-lg-3">
+            <div class="col-xs">
               <p><img src="{{ get_url(path=page.extra.feature_photo) }}" style="max-width: 100%; margin-top: 3rem; border-radius: 50%;" /></p>
             </div>
-            <div class="col-lg-8 col-lg-offset-1">
+            <div class="col-xs">
           {% else %}
-              <div class="col-xs-12">
+              <div class="col-xs">
           {% endif %}
           <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
           <p>{{ page.summary | safe }}</p>

--- a/templates/section.html
+++ b/templates/section.html
@@ -28,7 +28,7 @@
     <div class="container">
       {% for post in section.pages %}
       <section class="row">
-        <article class="col-lg-12">
+        <article class="col-xs">
             <h2><a href="{{ post.permalink }}" title="{{ post.title }}">{{ post.title }}</a></h2>
             <p>
               <time>{{ post.date | date(format="%B %d, %Y") }}</time>
@@ -59,7 +59,7 @@
   <section id="products">
     <div class="row">
         {% for page in section.pages %}
-        <div class="col-sm" {% if loop.index % 2 == 0 %}{% endif %}>
+        <div class="col-xs" {% if loop.index % 2 == 0 %}{% endif %}>
             {% if page.extra.feature_photo != "" %}
             <div class="row">
                 <div class="product-logo box">
@@ -70,7 +70,7 @@
             </div>
         {% endif %}
         <div class="row">
-            <div class="col-sm small"> 
+            <div class="col-xs"> 
                 {{ page.summary | safe }}
             </div>
         </div>
@@ -90,12 +90,12 @@
       <div class="container">
         <section class="row">
           {% if page.extra.feature_photo != "" %}
-            <div class="col-lg-3">
+            <div class="col-xs-3">
               <p><img src="{{ get_url(path=page.extra.feature_photo) }}" style="max-width: 100%; margin-top: 3rem; border-radius: 50%;" /></p>
             </div>
-            <div class="col-lg-8 col-lg-offset-1">
+            <div class="col-xs-8">
           {% else %}
-              <div class="col-xs-12">
+              <div class="col-xs">
           {% endif %}
           <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
           <p>{{ page.summary | striptags }}</p>


### PR DESCRIPTION
Margins were too small on mobile in some pages. Tweaking mobile meadi query and emoving numbers from `col-` classes lets flexboxgrid magically fix it.


<img width="451" alt="squirelly" src="https://github.com/user-attachments/assets/e6fdb12d-ef5d-4b4b-bf72-39594ca7c8fc" />
<img width="439" alt="fixed" src="https://github.com/user-attachments/assets/1d65e961-8c2b-4031-8f1c-5b8d5df47fb3" />
