### PR TITLE
Create funding.json

### DIFF
--- a/static/funding.json
+++ b/static/funding.json
@@ -17,6 +17,7 @@
             "description": "Limecast is a distributed, privacy-first podcast platform and CMS written in Rust. Using a simple web UI, Limecast handles content management, hosting of podcast audio and artwork assets, RSS and Atom feed creation, and automatically creates a visually appealing website and social sharing links for each podcast in the system. Limecast is deployed as a single binary and uses minimal system resources to operate.",
             "webpageUrl": {
                 "url": "https://limecast.net",
+                "wellKnown": "https://limecast.net/.well-known/funding-manifest-urls"
             },
             "repositoryUrl": {
                 "url": "https://codeberg.org/limeleaf/limecast",
@@ -44,6 +45,7 @@
             },
             "repositoryUrl": {
                 "url": "https://codeberg.org/limeleaf/apply-coop",
+                "wellKnown": "https://codeberg.org/limeleaf/apply-coop/src/branch/main/static/.well-known/funding-manifest-urls"
             },
             "licenses": [
                 "spdx:MPL-2.0"


### PR DESCRIPTION
Please review the project descriptions. 

Orgs like [Foss.fund](https://floss.fund) require [one of these files](https://fundingjson.org/) to be considered for funding. Once this PR lands, I will also add the required WellKnown `funding-manifest-urls` files to the apply and limecast repos.